### PR TITLE
feat(dashboard): delete storage files

### DIFF
--- a/src/lib/deleteFilesInFolder.js
+++ b/src/lib/deleteFilesInFolder.js
@@ -1,0 +1,20 @@
+import { deleteObject, listAll, ref } from "firebase/storage";
+
+export async function deleteFilesInFolder(storage, folderPath) {
+  const folderRef = ref(storage, folderPath);
+
+  try {
+    const items = await listAll(folderRef);
+
+    //Loop through the items in the folder
+    const deletePromises = items.items.map((itemRef) => {
+      //Delete the file
+      return deleteObject(itemRef);
+    });
+
+    //Wait for all file deletion operations to complete
+    await Promise.all(deletePromises);
+  } catch (error) {
+    throw new Error(error);
+  }
+}

--- a/src/lib/useDeleteDoc.js
+++ b/src/lib/useDeleteDoc.js
@@ -2,7 +2,8 @@ import { deleteDoc, doc } from "firebase/firestore";
 import { useState } from "react";
 import { toast } from "react-toastify";
 
-import { db } from "./firebase";
+import { deleteFilesInFolder } from "./deleteFilesInFolder";
+import { db, storage } from "./firebase";
 
 function useDeleteDoc() {
   const [loading, setLoading] = useState(false);
@@ -10,8 +11,13 @@ function useDeleteDoc() {
   const deleteItem = async (itemId) => {
     setLoading(true);
     try {
+      //delete the firestore doc
       const itemDocRef = doc(db, "items", itemId);
       await deleteDoc(itemDocRef);
+
+      //delete associated images in Storage
+      await deleteFilesInFolder(storage, `items/${itemId}/`);
+
       toast.success("Item deleted ✅", {
         position: toast.POSITION.TOP_CENTER,
         autoClose: 1500,


### PR DESCRIPTION
## Implement Deletion of Storage Files

**PR Description:**
This pull request addresses the issue of maintaining data cleanliness and efficient storage usage within our application. As it stands, when users delete a listed item from their dashboard, the associated Firestore document is deleted, but the corresponding files in Firebase Storage remain intact. To ensure our database stays organized and storage space is used optimally, this PR implements a new feature: the deletion of both the Firestore document and associated storage files when a user deletes an item.

**Changes Made:**

- Added a JavaScript function for item deletion, which takes the unique identifier (Firestore document ID) as a parameter.
- In this function, the Firestore document is deleted.
- The function identifies and removes the associated files in Firebase Storage.
- Appropriate error handling and validation are implemented to ensure the operation is executed successfully.

**Testing:**

The feature has been tested to ensure that:

- It correctly deletes the Firestore document.
- It identifies and removes all associated files from Firebase Storage.
- Proper error handling is in place to handle any failures.

**Additional Notes:**

Proper permissions have been set up for Firebase Storage to allow for write and delete operations.

**Related Issues:** fixes #64 

**Code Added:**
1. function to delete all files inside a folder:
```javascript
export async function deleteFilesInFolder(storage, folderPath) {
  const folderRef = ref(storage, folderPath);

  try {
    const items = await listAll(folderRef);

    //Loop through the items in the folder
    const deletePromises = items.items.map((itemRef) => {
      //Delete the file
      return deleteObject(itemRef);
    });

    //Wait for all file deletion operations to complete
    await Promise.all(deletePromises);
  } catch (error) {
    throw new Error(error);
  }
}
```
2. Usage inside our delete doc function:
```javascript
 await deleteFilesInFolder(storage, `items/${itemId}/`);
```

This PR is an essential improvement for maintaining data integrity and efficient storage usage in our app. By ensuring that both Firestore documents and their associated storage files are removed when users delete items, we're taking steps to keep our application clean and user-friendly.

# Related Issue

- Resolve #64