### PR TITLE
style(auth pages): fix overflow

### DIFF
--- a/public/locales/en/signUp.json
+++ b/public/locales/en/signUp.json
@@ -21,7 +21,7 @@
   "phoneLabel": "Phone",
   "phonePlaceholder": "Enter your phone number",
   "phoneRequired": "Phone number is required",
-  "locationLabel": "Province",
+  "locationLabel": "Wilaya",
   "locationRequired": "Location is required",
   "signUpMethod": "Sign up using",
   "divider": "OR"

--- a/src/components/SignInForm/__test__/__snapshots__/ResetForm.test.js.snap
+++ b/src/components/SignInForm/__test__/__snapshots__/ResetForm.test.js.snap
@@ -2,13 +2,13 @@
 
 exports[`renders correctly 1`] = `
 <section
-  className="flex gap-2 flex-col w-full mx-auto"
+  className="flex flex-col w-full mx-auto"
 >
   <h1
     className="text-3xl font-bold mb-8"
   />
   <form
-    className="flex flex-col gap-2"
+    className="flex flex-col"
     onSubmit={[Function]}
   >
     <div>
@@ -56,7 +56,7 @@ exports[`renders correctly 1`] = `
       />
     </div>
     <div
-      className="flex flex-col md:flex-row justify-between md:items-center flex-wrap"
+      className="flex my-2 flex-col md:flex-row justify-between md:items-center flex-wrap"
     >
       <div>
         <div

--- a/src/components/SignInForm/__test__/__snapshots__/ResetForm.test.js.snap
+++ b/src/components/SignInForm/__test__/__snapshots__/ResetForm.test.js.snap
@@ -2,13 +2,13 @@
 
 exports[`renders correctly 1`] = `
 <section
-  className="flex flex-col w-full mx-auto"
+  className="flex flex-col gap-2 w-full mx-auto"
 >
   <h1
     className="text-3xl font-bold mb-8"
   />
   <form
-    className="flex flex-col"
+    className="flex flex-col gap-2 "
     onSubmit={[Function]}
   >
     <div>
@@ -82,7 +82,7 @@ exports[`renders correctly 1`] = `
       />
     </div>
     <button
-      className="btn btn-secondary text-black bg-opacity-40 w-full normal-case text-xl font-normal self-center rounded-xl"
+      className="btn btn-secondary my-4 text-black bg-opacity-40 w-full normal-case text-xl font-normal self-center rounded-xl"
       disabled={false}
       type="submit"
     />

--- a/src/components/SignInForm/__test__/__snapshots__/SignInForm.test.js.snap
+++ b/src/components/SignInForm/__test__/__snapshots__/SignInForm.test.js.snap
@@ -2,13 +2,13 @@
 
 exports[`renders correctly 1`] = `
 <section
-  className="flex gap-2 flex-col w-full mx-auto"
+  className="flex flex-col w-full mx-auto"
 >
   <h1
     className="text-3xl font-bold mb-8"
   />
   <form
-    className="flex flex-col gap-2"
+    className="flex flex-col"
     onSubmit={[Function]}
   >
     <div>
@@ -56,7 +56,7 @@ exports[`renders correctly 1`] = `
       />
     </div>
     <div
-      className="flex flex-col md:flex-row justify-between md:items-center flex-wrap"
+      className="flex my-2 flex-col md:flex-row justify-between md:items-center flex-wrap"
     >
       <div>
         <div

--- a/src/components/SignInForm/__test__/__snapshots__/SignInForm.test.js.snap
+++ b/src/components/SignInForm/__test__/__snapshots__/SignInForm.test.js.snap
@@ -2,13 +2,13 @@
 
 exports[`renders correctly 1`] = `
 <section
-  className="flex flex-col w-full mx-auto"
+  className="flex flex-col gap-2 w-full mx-auto"
 >
   <h1
     className="text-3xl font-bold mb-8"
   />
   <form
-    className="flex flex-col"
+    className="flex flex-col gap-2 "
     onSubmit={[Function]}
   >
     <div>
@@ -82,7 +82,7 @@ exports[`renders correctly 1`] = `
       />
     </div>
     <button
-      className="btn btn-secondary text-black bg-opacity-40 w-full normal-case text-xl font-normal self-center rounded-xl"
+      className="btn btn-secondary my-4 text-black bg-opacity-40 w-full normal-case text-xl font-normal self-center rounded-xl"
       disabled={false}
       type="submit"
     />

--- a/src/components/SignInForm/index.jsx
+++ b/src/components/SignInForm/index.jsx
@@ -34,10 +34,10 @@ function SignInForm({ t }) {
   });
 
   return (
-    <section className='flex flex-col w-full mx-auto'>
+    <section className='flex flex-col gap-2 w-full mx-auto'>
       <h1 className='text-3xl font-bold mb-8'>{t("signIn:signIn")}</h1>
       {/* Form Section */}
-      <form className='flex flex-col' onSubmit={formik.handleSubmit}>
+      <form className='flex flex-col gap-2 ' onSubmit={formik.handleSubmit}>
         <Input
           name='email'
           type='email'
@@ -80,7 +80,7 @@ function SignInForm({ t }) {
         </div>
         {/* Login Button */}
         <button
-          className='btn btn-secondary text-black bg-opacity-40 w-full normal-case text-xl font-normal self-center rounded-xl'
+          className='btn btn-secondary my-4 text-black bg-opacity-40 w-full normal-case text-xl font-normal self-center rounded-xl'
           type='submit'
           disabled={formik.isSubmitting}
         >

--- a/src/components/SignInForm/index.jsx
+++ b/src/components/SignInForm/index.jsx
@@ -34,10 +34,10 @@ function SignInForm({ t }) {
   });
 
   return (
-    <section className='flex gap-2 flex-col w-full mx-auto'>
+    <section className='flex flex-col w-full mx-auto'>
       <h1 className='text-3xl font-bold mb-8'>{t("signIn:signIn")}</h1>
       {/* Form Section */}
-      <form className='flex flex-col gap-2' onSubmit={formik.handleSubmit}>
+      <form className='flex flex-col' onSubmit={formik.handleSubmit}>
         <Input
           name='email'
           type='email'
@@ -61,7 +61,7 @@ function SignInForm({ t }) {
           touched={formik.touched.password}
         />
         {/* Checkbox & Password Forgotten Section */}
-        <div className='flex flex-col md:flex-row justify-between md:items-center flex-wrap'>
+        <div className='flex my-2 flex-col md:flex-row justify-between md:items-center flex-wrap'>
           <Checkbox
             name='save'
             label={t("signIn:savedlogin")}

--- a/src/components/SignUpForm/__test__/__snapshots__/SignUpForm.test.js.snap
+++ b/src/components/SignUpForm/__test__/__snapshots__/SignUpForm.test.js.snap
@@ -2,13 +2,13 @@
 
 exports[`renders correctly 1`] = `
 <section
-  className="flex flex-col w-full mx-auto"
+  className="flex gap-2 flex-col w-full mx-auto"
 >
   <h1
     className="text-3xl font-bold"
   />
   <form
-    className="flex flex-col"
+    className="flex gap-2 flex-col"
     onSubmit={[Function]}
   >
     <div>
@@ -156,7 +156,7 @@ exports[`renders correctly 1`] = `
       className="divider"
     />
     <p
-      className="text-center"
+      className="text-center my-4"
     />
     <div
       className="flex gap-2 justify-center items-center text-3xl"

--- a/src/components/SignUpForm/__test__/__snapshots__/SignUpForm.test.js.snap
+++ b/src/components/SignUpForm/__test__/__snapshots__/SignUpForm.test.js.snap
@@ -2,13 +2,13 @@
 
 exports[`renders correctly 1`] = `
 <section
-  className="flex gap-2 flex-col w-full mx-auto"
+  className="flex flex-col w-full mx-auto"
 >
   <h1
     className="text-3xl font-bold"
   />
   <form
-    className="flex flex-col gap-2"
+    className="flex flex-col"
     onSubmit={[Function]}
   >
     <div>
@@ -145,7 +145,7 @@ exports[`renders correctly 1`] = `
       </select>
     </div>
     <button
-      className="btn mt-2 btn-secondary text-black bg-opacity-40 w-full normal-case text-xl font-normal self-center rounded-xl"
+      className="btn my-6 btn-secondary text-black bg-opacity-40 w-full normal-case text-xl font-normal self-center rounded-xl"
       type="submit"
     />
   </form>

--- a/src/components/SignUpForm/index.jsx
+++ b/src/components/SignUpForm/index.jsx
@@ -47,9 +47,9 @@ function SignUpForm({ states, t }) {
   });
 
   return (
-    <section className='flex gap-2 flex-col w-full mx-auto'>
+    <section className='flex flex-col w-full mx-auto'>
       <h1 className='text-3xl font-bold'>{t("signUp:signUp")}</h1>
-      <form onSubmit={formik.handleSubmit} className='flex flex-col gap-2'>
+      <form onSubmit={formik.handleSubmit} className='flex flex-col'>
         <Input
           name='name'
           type='text'
@@ -117,7 +117,7 @@ function SignUpForm({ states, t }) {
         />
         <button
           type='submit'
-          className='btn mt-2 btn-secondary text-black bg-opacity-40 w-full normal-case text-xl font-normal self-center rounded-xl'
+          className='btn my-6 btn-secondary text-black bg-opacity-40 w-full normal-case text-xl font-normal self-center rounded-xl'
         >
           {t("signUp:signUpButton")}
         </button>

--- a/src/components/SignUpForm/index.jsx
+++ b/src/components/SignUpForm/index.jsx
@@ -47,9 +47,9 @@ function SignUpForm({ states, t }) {
   });
 
   return (
-    <section className='flex flex-col w-full mx-auto'>
+    <section className='flex gap-2 flex-col w-full mx-auto'>
       <h1 className='text-3xl font-bold'>{t("signUp:signUp")}</h1>
-      <form onSubmit={formik.handleSubmit} className='flex flex-col'>
+      <form onSubmit={formik.handleSubmit} className='flex gap-2 flex-col'>
         <Input
           name='name'
           type='text'
@@ -124,7 +124,7 @@ function SignUpForm({ states, t }) {
       </form>
       <div className='lg:hidden'>
         <span className='divider'>{t("signUp:divider")}</span>
-        <p className='text-center'>{t("signUp:signUpMethod")}</p>
+        <p className='text-center my-4'>{t("signUp:signUpMethod")}</p>
         <SignupMethods />
       </div>
     </section>

--- a/src/pages/auth/sign-in/index.jsx
+++ b/src/pages/auth/sign-in/index.jsx
@@ -11,7 +11,7 @@ function SignInPage({ t, _nextI18Next }) {
   return (
     <AuthPagesLayout>
       <main
-        className='flex justify-between items-center min-h-screen'
+        className='flex justify-between items-center lg:h-screen lg:overflow-hidden'
         dir={initialLocale === "ar" ? "rtl" : "ltr"}
       >
         <div className='flex shadow-2xl flex-col min-h-screen mx-auto justify-center w-full p-4 md:px-20 lg:px-8'>

--- a/src/pages/auth/sign-in/index.jsx
+++ b/src/pages/auth/sign-in/index.jsx
@@ -11,21 +11,21 @@ function SignInPage({ t, _nextI18Next }) {
   return (
     <AuthPagesLayout>
       <main
-        className='flex justify-between items-center lg:h-screen lg:overflow-hidden'
+        className='flex justify-between min-h-screen'
         dir={initialLocale === "ar" ? "rtl" : "ltr"}
       >
-        <div className='flex shadow-2xl flex-col min-h-screen mx-auto justify-center w-full p-4 md:px-20 lg:px-8'>
+        <div className='flex shadow-2xl flex-col min-h-screen mx-auto w-full p-4 md:px-20 lg:px-8'>
           <div className='navbar'></div>
           <SignInForm t={t} />
         </div>
-        <figure className='hidden h-screen lg:block md:w-[60%] relative flex-shrink-0 saturate-0'>
+        <figure className='hidden max-h-full lg:block md:w-[60%] relative flex-shrink-0 saturate-0'>
           <Image
             src='/images/signin.jpg'
             priority
             alt='test'
             width={2000}
             height={2000}
-            className='object-cover w-full h-full overflow-hidden'
+            className='object-cover w-full  min-h-screen max-h-[820px]'
           />
         </figure>
       </main>

--- a/src/pages/auth/sign-up/index.jsx
+++ b/src/pages/auth/sign-up/index.jsx
@@ -27,17 +27,17 @@ function SignUpPage({ _nextI18Next, t }) {
   return (
     <AuthPagesLayout>
       <main
-        className='flex justify-between items-center lg:h-screen lg:overflow-hidden'
+        className='flex justify-between min-h-screen'
         dir={initialLocale === "ar" ? "rtl" : "ltr"}
       >
-        <figure className='relative hidden lg:block md:w-[60%] h-screen flex-shrink-0'>
+        <figure className='relative hidden lg:block md:w-[60%] max-h-full flex-shrink-0'>
           <Image
             src='/images/signin.jpg'
             priority
             alt='test'
             width={2000}
             height={2000}
-            className='object-cover saturate-0 w-full h-full'
+            className='object-cover saturate-0 w-full min-h-screen max-h-[820px]'
           />
           <motion.div
             variants={signUpMethodsAnim}
@@ -51,8 +51,8 @@ function SignUpPage({ _nextI18Next, t }) {
             <SignupMethods />
           </motion.div>
         </figure>
-        <div className='flex shadow-2xl py-4 lg:py-4 flex-col h-full mx-auto lg:overflow-y-scroll justify-center w-full p-4 md:px-20 lg:px-8'>
-          <div className='navbar lg:mb-4'></div>
+        <div className='flex shadow-2xl py-4 flex-col min-h-screen mx-auto w-full p-4 md:px-20 lg:px-8'>
+          <div className='navbar'></div>
           <SignUpForm states={states} t={t} />
         </div>
       </main>

--- a/src/pages/auth/sign-up/index.jsx
+++ b/src/pages/auth/sign-up/index.jsx
@@ -27,10 +27,10 @@ function SignUpPage({ _nextI18Next, t }) {
   return (
     <AuthPagesLayout>
       <main
-        className='flex justify-between items-center min-h-screen lg:h-screen lg:overflow-hidden'
+        className='flex justify-between items-center lg:h-screen lg:overflow-hidden'
         dir={initialLocale === "ar" ? "rtl" : "ltr"}
       >
-        <figure className='relative hidden lg:block md:w-[60%] min-h-screen flex-shrink-0'>
+        <figure className='relative hidden lg:block md:w-[60%] h-screen flex-shrink-0'>
           <Image
             src='/images/signin.jpg'
             priority
@@ -43,7 +43,7 @@ function SignUpPage({ _nextI18Next, t }) {
             variants={signUpMethodsAnim}
             initial='hidden'
             animate='visible'
-            className='absolute flex-col gap-4 shadow-xl backdrop-blur-sm bg-opacity-25 hover:bg-opacity-50 transition-all duration-500 ease-in-out border-2 border-white border-opacity-20 top-[45%] left-[30%] bg-base-100 rounded-xl w-[40%] h-[14%] flex items-center justify-center'
+            className='absolute flex-col gap-4 shadow-xl backdrop-blur-sm bg-opacity-25 hover:bg-opacity-50 transition-all duration-500 ease-in-out border-2 border-white border-opacity-20 top-[45%] left-[30%] bg-base-100 rounded-xl w-[40%] h-[22%] flex items-center justify-center'
           >
             <h3 className='text-center font-bold text-2xl'>
               {t("signUp:signUpMethod")}
@@ -51,8 +51,8 @@ function SignUpPage({ _nextI18Next, t }) {
             <SignupMethods />
           </motion.div>
         </figure>
-        <div className='flex shadow-2xl flex-col min-h-screen mx-auto justify-center w-full p-4 md:px-20 lg:px-8'>
-          <div className='navbar'></div>
+        <div className='flex shadow-2xl py-4 lg:py-4 flex-col h-full mx-auto lg:overflow-y-scroll justify-center w-full p-4 md:px-20 lg:px-8'>
+          <div className='navbar lg:mb-4'></div>
           <SignUpForm states={states} t={t} />
         </div>
       </main>


### PR DESCRIPTION
## Fix overflow on auth pages

fixes #105

**Description:**
in this pull request, I have solved the problem of the auth pages overflowing on smaller devices.

**Fixes:**

- Fix sign-in page image shrinking behavior on smaller devices
- Fix Sign-up form overflow

**Screenshots:**
![image](https://github.com/202306-NEA-DZ-FEW/team-a/assets/85134557/7ab7c163-563b-4495-b66d-fc83dc93d9e3)
![image](https://github.com/202306-NEA-DZ-FEW/team-a/assets/85134557/1769b2f2-1aed-42a7-8012-4e377deae292)
The sign-up form on the right is scrollable when there is an overflow 

**Request for Review:**
I invite my teammates to review these changes and provide feedback. The goal is to create an authentication process that aligns seamlessly with our website's theme and provides users with a visually pleasing and intuitive experience.



# Related Issue

- Resolve #105